### PR TITLE
explicit miner axon params

### DIFF
--- a/template/base/miner.py
+++ b/template/base/miner.py
@@ -120,9 +120,15 @@ class BaseMinerNeuron(BaseNeuron):
         ]
 
         # The axon handles request processing, allowing validators to send this miner requests.
-        self.axon = bt.axon(wallet=self.wallet, port=self.config.axon.port,external_port=self.config.axon.port,external_ip=self.config.dht.announce_ip) 
-        # self.axon = bt.axon(wallet=self.wallet, config=self.config) #Thanks Alex !
-        
+        # https://github.com/opentensor/bittensor/blob/935217242ef8b48ecf0d63f9bb0b920905c8cda8/bittensor/axon.py#L331
+        self.axon = bt.axon(
+            wallet=self.wallet,
+            port=self.config.axon.port,
+            external_port=self.config.axon.external_port,
+            ip=self.config.dht.announce_ip,
+            external_ip=self.config.dht.announce_ip,
+        )
+
         # Attach determiners which functions are called when servicing a request.
         bt.logging.info(f"Attaching forward function to miner axon.")
         self.axon.attach(


### PR DESCRIPTION
Explicit miner axon params ensure that the parsing of user manual configs versus default fallbacks are as expected.

https://github.com/opentensor/bittensor/blob/935217242ef8b48ecf0d63f9bb0b920905c8cda8/bittensor/axon.py#L331
![image](https://github.com/bit-current/DistributedTraining/assets/69808183/fed25b5c-afd4-406e-a095-454d9938f048)

Example of complex port forwarding that need manual specification:
![image](https://github.com/bit-current/DistributedTraining/assets/69808183/95b705b0-a527-46c4-ad9f-feb298fd798b)

