### PR TITLE
 Optimize the peer list updating process

### DIFF
--- a/template/base/miner.py
+++ b/template/base/miner.py
@@ -75,16 +75,14 @@ class BaseMinerNeuron(BaseNeuron):
 
         # Init list of available DHT addresses from wandb
         api = wandb.Api()
-        initial_peers_list = self.config.neuron.initial_peers
+        initial_peers_list = set(self.config.neuron.initial_peers)
         runs = api.runs(
             f"{self.config.neuron.wandb_entity}/{self.config.neuron.wandb_project}"
         )
         for ru in runs:
             if ru.state == "running":
-                for peer in ru.config["neuron"]["initial_peers"]:
-                    if peer not in initial_peers_list:
-                        initial_peers_list.append(peer)
-
+                initial_peers_list.update(ru.config["neuron"]["initial_peers"])
+        initial_peers_list = list(initial_peers_list)
         # Init DHT
         retries = 0
         while retries <= len(initial_peers_list):


### PR DESCRIPTION
The code looks into list of running mining and then looks into their list of peers on start up. This list is growing exponentially over time slowing down the start up process. This pull request replaces the nested loop that goes over each value of the list one by one and insert peer in the peer list array with unique values with using hashtable with O(1)